### PR TITLE
Edit language and process in bootstrap document

### DIFF
--- a/bootstrapping_decision_making.md
+++ b/bootstrapping_decision_making.md
@@ -1,33 +1,34 @@
 # Bootstrapping Decision Making Bodies
 
-As the new Jupyter governance model is approved and implemented, Jupyter Subprojects will have to establish a formal decision making body. There are a number of challenges associated with this:
+As the new Jupyter governance model is approved and implemented, we are moving from an informal Subproject governance model to a formal model. As part of this process, each Jupyter Subproject will need to establish a formal decision-making body, including deciding its size and who its members are. There are a number of challenges associated with this:
 
-- We are moving from an informal model where most Subprojects do not have a formal decision making body, to the formal one described in the Decision Making Guidelines.
-- Most Subprojects do not have a well defined decision making body today.
-- In the new model, there is flexibility about the size of the formal decision making bodies. Each Subproject will need to also determine how large its formal decision making body is.
-- There is a wide range of sizes of Subprojects &mdash; some have a few contributors and others have many dozens.
-- We are proposing to establish new Subprojects for certain areas of Project Jupyter, that don’t have an existing history of informal governance.
-- The new governance model and [decision making guide](decision_making.md) is designed to support large, highly participatory decision making bodies. As such, even Subprojects that have a clear decision making body today, may wish to increase the size of that body to include more contributors.
-- Our current governance model (informal consensus by an informal group lacking clear boundaries) does not have an established mechanism for decisions like this. We believe it will be very difficult for Subprojects to elect a formal governing body and pick its size using informal consensus.
-- We wish to avoid each Subproject having layers of meta consensus or voting to establish a process for electing their decision making body.
-- We need to take existing Steering Council members into account. There may be Steering Council members that would like to be on the formal decision making body for a Subproject, even though they have not been active on the Suproject for a period of time.
+- Most Subprojects do not currently have a well-defined decision process or decision-making body.
+- There is a wide range of Subproject community sizes and activity&mdash;some have only a few contributors and infrequent commits, while others have dozens of developers and daily activity.
+- We are proposing to establish new Subprojects for certain areas of Project Jupyter (or combining related areas) that do not have an existing history of informal governance.
+- The new governance model and [decision-making guide](decision_making.md) is designed to support large, highly participatory decision making bodies. As such, even Subprojects that have a clear decision-making body today may wish to increase the size of that body to include more contributors.
+- We wish to avoid each Subproject having layers of meta consensus or voting to establish very different processes for electing their decision-making body.
+- We wish to involve the current Steering Council in forming Subproject decision-making bodies.
 
 ## Proposed framework
 
-We would like to propose the following framework for Subprojects to establish and bootstrap their formal decision making bodies. This framework is not being presented as a set of strict rules, but more as a set of flexible principles that Subprojects can use for this task. The Governance Working Group will be available to meet with all Subprojects to openly discuss how the Subproject can best use and adapt these ideas to their case.
+We propose the following framework for Subprojects to establish and bootstrap their formal decision-making bodies. This framework is a suggested process and guiding set of principles that can be adapted to a particular Subproject's existing circumstances. The Governance Working Group will be available to meet with any Subproject to openly discuss how the Subproject can best use and adapt these ideas to their existing structure and needs.
 
-The overall principle of this framework is that of gradual accumulation of the decision making body, rather than bulk election. The process we propose can be briefly outlined as follows:
+The overall principle of this framework is to gradually grow the decision-making body from a trusted, respected, and well-defined group. The process we propose is:
 
 
-- Each Subproject typically has a core of individuals who have a long history with the Subproject and have made significant contributions to the Subproject (in many cases, they founded the Subproject). There is universal agreement that these people should be on the formal decision making body for the Subproject. An example would be Min for JupyterHub. This initial group can be as small as a single person and keeping it as small as possible ensures this step will be simple. Let’s call the size of this initial group `N0`.
-- Once the initial group or person is established, that group will use the new Decision Making Guidelines to elect the next single member they would like to add to the formal decision making body. At this point, the decision making body would have size `N0+1`.
-- At this point, the `N0+1` people would use the Decision Making Guidelines to elect the next single member to add to the decision make body.
-- This process continues in an inductive manner where at each point, the current `N` people on the decision making body elect the `N+1` person, or choose to stop electing new members.
+1. Jupyter Steering Council members will sign up to each Subproject in which they wish to be on the decision-making body. This forms the initial decision-making body for each Subproject.
+2. The decision-making body uses the new Decision Making Guidelines and the principles below to decide if the next action should be:
+   A. Electing a single new member to the decision-making body, in which case the process proceeds to step 3, or
+   B. Stopping electing members, in which case the decision-making body is complete and the process ends.
+3. The current decision-making body elects a single new member using the Decision Making Guidelines and the principles below, thereby increasing the body's size by one, and proceeds to step 2.
 
-This framework has the following characteristics:
+The bootstrapping process should observe these principles:
+- To address issues of multi-stakeholder governance, during the process above, successively elected members in step 3 should rotate across different organizations to avoid overrepresentation of a single organization in a stage of the process.
+- Decision-making bodies should be inclusive and as large as necessary to give voice to contributors who are actively working on the Subproject or working group. This should be evaluated in both steps 2 and 3 of the process above.
 
-- By gradually increasing the size of the decision making body one person at a time, the power implicit in this election process is gradually distributed over a larger group of people.
-- At each stage where the new decision making body is considering adding a new person, they can also choose to stop electing additional members. This allows the group to decide on the overall size in an organic, gradual manner.
-- The bootstrapping process should address issues of multi-stakeholder governance. Specifically, during bootstrapping, decision making bodies should rotate new members across different organizations to avoid overrepresentation of a single organization.
-- Decision making bodies should be inclusive and as large as necessary to give voice to contributors who are actively working on the subproject or working group.
-- As explained in the SSC document, there will be a working group with an SSC representative focused on issues of Inclusive Community Development. This representative can be a point of contact to assist with any issue regarding inclusion and participation in the creation of the project decision making bodies.
+This process has the following characteristics:
+
+- By seeding each decision-making body from the Steering Council, we start each process from a clear starting point.
+- By gradually increasing the size of the decision-making body one person at a time, the power implicit in this election process is gradually distributed over a larger group of people.
+- At each stage where the new decision-making body is considering adding a new person, they can also choose to stop electing additional members. This allows the group to decide on the overall size in an organic, gradual manner.
+- At each step, issues of diversity and inclusion of the representative body are considered.

--- a/bootstrapping_decision_making.md
+++ b/bootstrapping_decision_making.md
@@ -28,7 +28,7 @@ The bootstrapping process should observe these principles:
 
 This process has the following characteristics:
 
-- By seeding each decision-making body from the Steering Council, we start each process from a clear starting point.
+- By seeding each decision-making body from the current Steering Council, we start each process from a clear starting point.
 - By gradually increasing the size of the decision-making body one person at a time, the power implicit in this election process is gradually distributed over a larger group of people.
 - At each stage where the new decision-making body is considering adding a new person, they can also choose to stop electing additional members. This allows the group to decide on the overall size in an organic, gradual manner.
 - At each step, issues of diversity and inclusion of the representative body are considered.


### PR DESCRIPTION
This is a follow up from conversations in the governance office hours today about review comments of the bootstrapping process.

- Reorganizes and condenses a lot of the text, but tries to capture the original intent
- Seeds the initial decision-making bodies of subprojects from the steering council so we have a clear starting point
- Adds the principle of explicit evaluation of inclusion and diversity at each step of growing a decision-making body.